### PR TITLE
Implemented HMAC-SHA256 signature support to OAuth1.

### DIFF
--- a/src/OAuth/OAuth1/Service/AbstractService.php
+++ b/src/OAuth/OAuth1/Service/AbstractService.php
@@ -23,6 +23,9 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
     /** @var null|UriInterface */
     protected $baseApiUri;
 
+    /** @var string */
+    protected $signatureMethod = 'HMAC-SHA1';
+
     /**
      * {@inheritdoc}
      */
@@ -274,17 +277,18 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
      */
     protected function getSignatureMethod()
     {
-        return 'HMAC-SHA1';
+        return $this->signatureMethod;
     }
 
     /**
-     * This returns the version used in the authorization header of the requests.
+     * Set the signature method.
+     * Currently supported: 'HMAC-SHA1' and 'HMAC-SHA256'
      *
-     * @return string
+     * @param string $method
      */
-    protected function getVersion()
+    protected function setSignatureMethod($method)
     {
-        return '1.0';
+        $this->signatureMethod = (string) $method;
     }
 
     /**

--- a/src/OAuth/OAuth1/Signature/Signature.php
+++ b/src/OAuth/OAuth1/Signature/Signature.php
@@ -114,6 +114,8 @@ class Signature implements SignatureInterface
         switch (strtoupper($this->algorithm)) {
             case 'HMAC-SHA1':
                 return hash_hmac('sha1', $data, $this->getSigningKey(), true);
+            case 'HMAC-SHA256':
+                return hash_hmac('sha256', $data, $this->getSigningKey(), true);
             default:
                 throw new UnsupportedHashAlgorithmException(
                     'Unsupported hashing algorithm (' . $this->algorithm . ') used.'


### PR DESCRIPTION
Example usage:
```php
class OauthClient extends \OAuth\OAuth1\Service\AbstractService
{
    public function __construct(
        Credentials $credentials,
        ClientInterface $httpClient = null,
        TokenStorageInterface $storage = null,
        SignatureInterface $signature = null,
        UriInterface $baseApiUri = null
    ) {
        $this->setSignatureMethod('HMAC-SHA256');  // <== THIS
        parent::__construct($credentials, $httpClient, $storage, $signature, $baseApiUri);
    }
}
```