### PR TITLE
After quite some debugging I found out the __sleep function in OAuth\…

### DIFF
--- a/src/OAuth/Common/Token/AbstractToken.php
+++ b/src/OAuth/Common/Token/AbstractToken.php
@@ -122,9 +122,4 @@ abstract class AbstractToken implements TokenInterface
         && $this->getEndOfLife() !== TokenInterface::EOL_UNKNOWN
         && time() > $this->getEndOfLife();
     }
-
-    public function __sleep()
-    {
-        return ['accessToken'];
-    }
 }


### PR DESCRIPTION
After quite some debugging I found out the `__sleep` function in `OAuth\Common\Token\AbstractToken` breaks the signature in Oauth1.